### PR TITLE
feat: add minimal ecs

### DIFF
--- a/Tasks.md
+++ b/Tasks.md
@@ -54,7 +54,7 @@ Output: PR mit README (Setup/Run), Badges, funktionierendem `pnpm dev`.
 
 ## 2) Engine & ECS
 
-- [ ] T-010: Minimal-ECS (Entities, Components SoA, Systems-Loop, Pools)
+- [x] T-010: Minimal-ECS (Entities, Components SoA, Systems-Loop, Pools)
 - [ ] T-011: Deterministischer Fixed-Step (60 Hz) + RNG (Xorshift128+)
 - [ ] T-012: Snapshot-Rewind (Ring-Buffer, 6–8 s, 100 ms, Replay)
 

--- a/src/ecs/component.ts
+++ b/src/ecs/component.ts
@@ -1,0 +1,86 @@
+import type { Entity } from './entity'
+
+export class ComponentStore<T extends Record<string, unknown>> {
+  private data: Record<keyof T, T[keyof T][]> = {} as Record<
+    keyof T,
+    T[keyof T][]
+  >
+  private index = new Map<Entity, number>()
+  public entities: Entity[] = []
+
+  constructor(keys: (keyof T)[]) {
+    for (const key of keys) {
+      this.data[key] = []
+    }
+  }
+
+  get size(): number {
+    return this.entities.length
+  }
+
+  has(entity: Entity): boolean {
+    return this.index.has(entity)
+  }
+
+  add(entity: Entity, value: T): void {
+    if (this.index.has(entity)) throw new Error('component already exists')
+    const idx = this.entities.length
+    this.entities.push(entity)
+    this.index.set(entity, idx)
+    for (const key in this.data) {
+      const k = key as keyof T
+      this.data[k].push(value[k])
+    }
+  }
+
+  get(entity: Entity): T | undefined {
+    const idx = this.index.get(entity)
+    if (idx === undefined) return undefined
+    const result = {} as Record<keyof T, T[keyof T]>
+    for (const key in this.data) {
+      const k = key as keyof T
+      result[k] = this.data[k][idx]
+    }
+    return result as T
+  }
+
+  set(entity: Entity, partial: Partial<T>): void {
+    const idx = this.index.get(entity)
+    if (idx === undefined) throw new Error('missing component')
+    for (const key in partial) {
+      const k = key as keyof T
+      this.data[k][idx] = partial[k] as T[typeof k]
+    }
+  }
+
+  remove(entity: Entity): void {
+    const idx = this.index.get(entity)
+    if (idx === undefined) return
+    const last = this.entities.length - 1
+    const lastEntity = this.entities[last]
+
+    for (const key in this.data) {
+      const k = key as keyof T
+      const arr = this.data[k]
+      arr[idx] = arr[last]
+      arr.pop()
+    }
+
+    this.entities[idx] = lastEntity
+    this.entities.pop()
+    this.index.set(lastEntity, idx)
+    this.index.delete(entity)
+  }
+
+  *each(): IterableIterator<[Entity, T]> {
+    for (let i = 0; i < this.entities.length; i++) {
+      const entity = this.entities[i]
+      const value = {} as Record<keyof T, T[keyof T]>
+      for (const key in this.data) {
+        const k = key as keyof T
+        value[k] = this.data[k][i]
+      }
+      yield [entity, value as T]
+    }
+  }
+}

--- a/src/ecs/entity.ts
+++ b/src/ecs/entity.ts
@@ -1,0 +1,14 @@
+export type Entity = number
+
+export class EntityManager {
+  private nextId: Entity = 0
+  private free: Entity[] = []
+
+  create(): Entity {
+    return this.free.pop() ?? this.nextId++
+  }
+
+  destroy(entity: Entity): void {
+    this.free.push(entity)
+  }
+}

--- a/src/ecs/index.ts
+++ b/src/ecs/index.ts
@@ -1,1 +1,4 @@
-// placeholder for ecs module
+export * from './entity'
+export * from './component'
+export * from './system'
+export * from './world'

--- a/src/ecs/system.ts
+++ b/src/ecs/system.ts
@@ -1,0 +1,5 @@
+import type { World } from './world'
+
+export interface System {
+  update(world: World, dt: number): void
+}

--- a/src/ecs/world.ts
+++ b/src/ecs/world.ts
@@ -1,0 +1,39 @@
+import { EntityManager, type Entity } from './entity'
+import type { ComponentStore } from './component'
+import type { System } from './system'
+
+export class World {
+  private entities = new EntityManager()
+  private systems: System[] = []
+
+  createEntity(): Entity {
+    return this.entities.create()
+  }
+
+  destroyEntity(entity: Entity): void {
+    this.entities.destroy(entity)
+  }
+
+  addSystem(system: System): void {
+    this.systems.push(system)
+  }
+
+  update(dt: number): void {
+    for (const system of this.systems) {
+      system.update(this, dt)
+    }
+  }
+
+  query(...stores: ComponentStore<unknown>[]): Entity[] {
+    if (stores.length === 0) return []
+    const smallest = stores.reduce((a, b) => (a.size < b.size ? a : b))
+    const result: Entity[] = []
+    outer: for (const entity of smallest.entities) {
+      for (const store of stores) {
+        if (!store.has(entity)) continue outer
+      }
+      result.push(entity)
+    }
+    return result
+  }
+}

--- a/tests/ecs.test.ts
+++ b/tests/ecs.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { ComponentStore, World, type System } from '@ecs/index'
+
+interface Position {
+  x: number
+  y: number
+}
+
+interface Velocity {
+  x: number
+  y: number
+}
+
+class MovementSystem implements System {
+  constructor(
+    private positions: ComponentStore<Position>,
+    private velocities: ComponentStore<Velocity>
+  ) {}
+
+  update(world: World, dt: number): void {
+    for (const entity of world.query(this.positions, this.velocities)) {
+      const pos = this.positions.get(entity)!
+      const vel = this.velocities.get(entity)!
+      this.positions.set(entity, {
+        x: pos.x + vel.x * dt,
+        y: pos.y + vel.y * dt,
+      })
+    }
+  }
+}
+
+describe('ecs', () => {
+  it('runs system loop and updates components', () => {
+    const world = new World()
+    const positions = new ComponentStore<Position>(['x', 'y'])
+    const velocities = new ComponentStore<Velocity>(['x', 'y'])
+    world.addSystem(new MovementSystem(positions, velocities))
+
+    const e = world.createEntity()
+    positions.add(e, { x: 0, y: 0 })
+    velocities.add(e, { x: 1, y: 1 })
+
+    world.update(1)
+
+    expect(positions.get(e)).toEqual({ x: 1, y: 1 })
+  })
+
+  it('reuses entity ids via pool', () => {
+    const world = new World()
+    const e1 = world.createEntity()
+    world.destroyEntity(e1)
+    const e2 = world.createEntity()
+    expect(e2).toBe(e1)
+  })
+})


### PR DESCRIPTION
## Summary
- implement component store with structure-of-arrays design
- add entity manager with id pooling and world system loop
- cover ECS behavior with unit tests

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6899e736da8c8330a8f4a27955a4d23f