### PR TITLE
feat(engine): add deterministic loop and RNG

### DIFF
--- a/Tasks.md
+++ b/Tasks.md
@@ -55,7 +55,7 @@ Output: PR mit README (Setup/Run), Badges, funktionierendem `pnpm dev`.
 ## 2) Engine & ECS
 
 - [x] T-010: Minimal-ECS (Entities, Components SoA, Systems-Loop, Pools)
-- [ ] T-011: Deterministischer Fixed-Step (60 Hz) + RNG (Xorshift128+)
+- [x] T-011: Deterministischer Fixed-Step (60 Hz) + RNG (Xorshift128+)
 - [ ] T-012: Snapshot-Rewind (Ring-Buffer, 6–8 s, 100 ms, Replay)
 
 **Prompt für Codex:**

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -1,1 +1,2 @@
-// placeholder for engine module
+export * from './loop'
+export * from './rng'

--- a/src/engine/loop.ts
+++ b/src/engine/loop.ts
@@ -1,0 +1,16 @@
+export type UpdateFn = (dt: number) => void
+
+export class FixedStepLoop {
+  private accumulator = 0
+
+  constructor(private readonly update: UpdateFn, private readonly step = 1 / 60) {}
+
+  advance(dt: number): void {
+    this.accumulator += dt
+    const steps = Math.floor(this.accumulator / this.step)
+    for (let i = 0; i < steps; i++) {
+      this.update(this.step)
+    }
+    this.accumulator -= steps * this.step
+  }
+}

--- a/src/engine/rng.ts
+++ b/src/engine/rng.ts
@@ -1,0 +1,33 @@
+export class Xorshift128Plus {
+  private s0: bigint
+  private s1: bigint
+
+  constructor(seed = 1n) {
+    let s = BigInt(seed)
+    if (s === 0n) s = 1n
+    // simple splitmix64 to fill state
+    this.s0 = this.splitMix64(s)
+    this.s1 = this.splitMix64(this.s0)
+  }
+
+  private splitMix64(seed: bigint): bigint {
+    let z = (seed + 0x9e3779b97f4a7c15n) & 0xffffffffffffffffn
+    z = (z ^ (z >> 30n)) * 0xbf58476d1ce4e5b9n & 0xffffffffffffffffn
+    z = (z ^ (z >> 27n)) * 0x94d049bb133111ebn & 0xffffffffffffffffn
+    return z ^ (z >> 31n)
+  }
+
+  next(): number {
+    let s1 = this.s0
+    const s0 = this.s1
+    this.s0 = s0
+    s1 ^= s1 << 23n
+    s1 ^= s1 >> 17n
+    s1 ^= s0
+    s1 ^= s0 >> 26n
+    this.s1 = s1
+    const result = (this.s0 + this.s1) & 0xffffffffffffffffn
+    // convert to double in [0,1)
+    return Number(result >> 11n) / Number(0x20000000000000n)
+  }
+}

--- a/tests/engine.test.ts
+++ b/tests/engine.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { FixedStepLoop, Xorshift128Plus } from '@engine/index'
+
+describe('engine', () => {
+  it('runs fixed-step updates', () => {
+    const steps: number[] = []
+    const loop = new FixedStepLoop(dt => steps.push(dt))
+    loop.advance(1)
+    expect(steps.length).toBe(60)
+    expect(steps.every(s => s === 1 / 60)).toBe(true)
+  })
+
+  it('is deterministic regardless of frame splits', () => {
+    let count1 = 0
+    const loop1 = new FixedStepLoop(() => count1++)
+    loop1.advance(1)
+
+    let count2 = 0
+    const loop2 = new FixedStepLoop(() => count2++)
+    loop2.advance(0.5)
+    loop2.advance(0.5)
+
+    expect(count1).toBe(count2)
+  })
+
+  it('generates deterministic RNG sequence', () => {
+    const rng1 = new Xorshift128Plus(123n)
+    const rng2 = new Xorshift128Plus(123n)
+    const seq1 = [rng1.next(), rng1.next(), rng1.next()]
+    const seq2 = [rng2.next(), rng2.next(), rng2.next()]
+    expect(seq1).toEqual([
+      0.4137666069746663,
+      0.7670110024952262,
+      0.6227989828702096,
+    ])
+    expect(seq1).toEqual(seq2)
+  })
+})


### PR DESCRIPTION
## Summary
- implement FixedStepLoop for 60Hz deterministic updates
- add Xorshift128+ RNG with splitmix64 seeding
- cover engine utilities with vitest and mark task T-011 complete

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6899e89fd1a0833089390fc6cb3cecf7