### PR TITLE
feat(path): add tilemap graph with phase-shift and overlay

### DIFF
--- a/Tasks.md
+++ b/Tasks.md
@@ -70,9 +70,9 @@ Snapshots: src/engine/snapshots.ts (capture/rewind/replay). Vitest: Desync-Schut
 
 ## 3) Pfade, Phase-Shift & Tilemap
 
-- [ ] T-020: Tilemap-Import (Tiled JSON) + Pfadgraph (A\*)
-- [ ] T-021: Phase-Shift: toggelbare Kanten/Segmente, deterministischer Recompute
-- [ ] T-022: Epoch-Overlay: Map-Layer + zonale Buffs/Resists (10–15 s)
+- [x] T-020: Tilemap-Import (Tiled JSON) + Pfadgraph (A\*)
+- [x] T-021: Phase-Shift: toggelbare Kanten/Segmente, deterministischer Recompute
+- [x] T-022: Epoch-Overlay: Map-Layer + zonale Buffs/Resists (10–15 s)
 
 **Prompt für Codex:**
 

--- a/src/path/graph.ts
+++ b/src/path/graph.ts
@@ -1,0 +1,146 @@
+export interface Node {
+  id: number
+  x: number
+  y: number
+}
+
+export interface Edge {
+  to: number
+  cost: number
+  id?: string
+  enabled: boolean
+}
+
+export class Graph {
+  private nodes = new Map<number, Node>()
+  private edges = new Map<number, Edge[]>()
+
+  addNode(node: Node): void {
+    this.nodes.set(node.id, node)
+  }
+
+  addEdge(
+    from: number,
+    to: number,
+    cost: number,
+    id?: string,
+    enabled = true
+  ): void {
+    const edge: Edge = { to, cost, id, enabled }
+    let list = this.edges.get(from)
+    if (!list) {
+      list = []
+      this.edges.set(from, list)
+    }
+    list.push(edge)
+  }
+
+  toggle(id: string): void {
+    for (const list of this.edges.values()) {
+      for (const edge of list) {
+        if (edge.id === id) {
+          edge.enabled = !edge.enabled
+        }
+      }
+    }
+  }
+
+  private heuristic(a: Node, b: Node): number {
+    return Math.abs(a.x - b.x) + Math.abs(a.y - b.y)
+  }
+
+  findPath(start: number, goal: number): number[] | undefined {
+    const startNode = this.nodes.get(start)
+    const goalNode = this.nodes.get(goal)
+    if (!startNode || !goalNode) return undefined
+
+    interface Record {
+      id: number
+      f: number
+    }
+
+    const open: Record[] = [{ id: start, f: this.heuristic(startNode, goalNode) }]
+    const cameFrom = new Map<number, number>()
+    const gScore = new Map<number, number>([[start, 0]])
+
+    while (open.length > 0) {
+      open.sort((a, b) => a.f - b.f || a.id - b.id)
+      const current = open.shift()!.id
+      if (current === goal) {
+        const path: number[] = [current]
+        while (cameFrom.has(path[0])) {
+          path.unshift(cameFrom.get(path[0])!)
+        }
+        return path
+      }
+
+      const currentG = gScore.get(current)!
+      for (const edge of this.edges.get(current) ?? []) {
+        if (!edge.enabled) continue
+        const tentativeG = currentG + edge.cost
+        const existingG = gScore.get(edge.to)
+        if (existingG === undefined || tentativeG < existingG) {
+          cameFrom.set(edge.to, current)
+          gScore.set(edge.to, tentativeG)
+          const f =
+            tentativeG +
+            this.heuristic(this.nodes.get(edge.to)!, goalNode)
+          const record = open.find(r => r.id === edge.to)
+          if (record) {
+            record.f = f
+          } else {
+            open.push({ id: edge.to, f })
+          }
+        }
+      }
+    }
+    return undefined
+  }
+}
+
+export interface TiledLayer {
+  name: string
+  data: number[]
+}
+
+export interface TiledMap {
+  width: number
+  height: number
+  layers: TiledLayer[]
+}
+
+export function graphFromTiled(
+  map: TiledMap,
+  layerName: string
+): Graph {
+  const layer = map.layers.find(l => l.name === layerName)
+  if (!layer) throw new Error('layer not found')
+  const graph = new Graph()
+  for (let y = 0; y < map.height; y++) {
+    for (let x = 0; x < map.width; x++) {
+      const idx = y * map.width + x
+      if (layer.data[idx] === 0) continue
+      graph.addNode({ id: idx, x, y })
+    }
+  }
+
+  for (let y = 0; y < map.height; y++) {
+    for (let x = 0; x < map.width; x++) {
+      const idx = y * map.width + x
+      if (layer.data[idx] === 0) continue
+      const neighbors = [
+        [x + 1, y],
+        [x - 1, y],
+        [x, y + 1],
+        [x, y - 1],
+      ]
+      for (const [nx, ny] of neighbors) {
+        if (nx < 0 || ny < 0 || nx >= map.width || ny >= map.height) continue
+        const nIdx = ny * map.width + nx
+        if (layer.data[nIdx] === 0) continue
+        graph.addEdge(idx, nIdx, 1)
+      }
+    }
+  }
+  return graph
+}

--- a/src/path/index.ts
+++ b/src/path/index.ts
@@ -1,1 +1,2 @@
-// placeholder for path module
+export * from './graph'
+export * from './overlay'

--- a/src/path/overlay.ts
+++ b/src/path/overlay.ts
@@ -1,0 +1,53 @@
+export interface OverlayZone {
+  x: number
+  y: number
+  width: number
+  height: number
+  buff: number
+  resist: number
+}
+
+export class EpochOverlay {
+  private active = false
+  private remaining = 0
+  private zones: OverlayZone[]
+  constructor(zones: OverlayZone[]) {
+    this.zones = zones
+  }
+
+  activate(duration: number): void {
+    this.active = true
+    this.remaining = duration
+  }
+
+  update(dt: number): void {
+    if (!this.active) return
+    this.remaining -= dt
+    if (this.remaining <= 0) {
+      this.active = false
+      this.remaining = 0
+    }
+  }
+
+  isActive(): boolean {
+    return this.active
+  }
+
+  getModifiers(x: number, y: number): { buff: number; resist: number } {
+    if (!this.active) return { buff: 0, resist: 0 }
+    let buff = 0
+    let resist = 0
+    for (const z of this.zones) {
+      if (
+        x >= z.x &&
+        y >= z.y &&
+        x < z.x + z.width &&
+        y < z.y + z.height
+      ) {
+        buff += z.buff
+        resist += z.resist
+      }
+    }
+    return { buff, resist }
+  }
+}

--- a/tests/path.test.ts
+++ b/tests/path.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { Graph, graphFromTiled, EpochOverlay } from '@path/index'
+
+describe('path graph', () => {
+  it('imports tiled map and computes A* path', () => {
+    const map = {
+      width: 2,
+      height: 1,
+      layers: [{ name: 'walk', data: [1, 1] }],
+    }
+    const g = graphFromTiled(map, 'walk')
+    const path = g.findPath(0, 1)
+    expect(path).toEqual([0, 1])
+  })
+
+  it('toggles phase-shift edges deterministically', () => {
+    const g = new Graph()
+    g.addNode({ id: 1, x: 0, y: 0 })
+    g.addNode({ id: 2, x: 1, y: 0 })
+    g.addNode({ id: 3, x: 1, y: 1 })
+    g.addNode({ id: 4, x: 2, y: 1 })
+    g.addEdge(1, 2, 1)
+    g.addEdge(2, 1, 1)
+    g.addEdge(2, 4, 1, 'phase', true)
+    g.addEdge(4, 2, 1, 'phase', true)
+    g.addEdge(2, 3, 1, 'phase', false)
+    g.addEdge(3, 2, 1, 'phase', false)
+    g.addEdge(3, 4, 1)
+    g.addEdge(4, 3, 1)
+    g.addEdge(1, 3, 5)
+    g.addEdge(3, 1, 5)
+
+    const path1 = g.findPath(1, 4)
+    expect(path1).toEqual([1, 2, 4])
+
+    g.toggle('phase')
+    const path2 = g.findPath(1, 4)
+    expect(path2).toEqual([1, 2, 3, 4])
+
+    g.toggle('phase')
+    const path3 = g.findPath(1, 4)
+    expect(path3).toEqual(path1)
+  })
+})
+
+describe('epoch overlay', () => {
+  it('applies buffs when active', () => {
+    const overlay = new EpochOverlay([
+      { x: 0, y: 0, width: 2, height: 2, buff: 0.5, resist: 0.3 },
+    ])
+    overlay.activate(10)
+    expect(overlay.getModifiers(1, 1)).toEqual({ buff: 0.5, resist: 0.3 })
+    overlay.update(10)
+    expect(overlay.getModifiers(1, 1)).toEqual({ buff: 0, resist: 0 })
+  })
+})


### PR DESCRIPTION
## Summary
- implement graph with A* pathfinding and phase-shift togglable edges
- add epoch overlay zones affecting buffs/resists
- cover tilemap import, phase-shift, and overlay with vitest

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6899f3d624508330bee6fb2bf8df602c