### PR TITLE
feat: add resources manager and wave spawner

### DIFF
--- a/src/content/waves.sample.json
+++ b/src/content/waves.sample.json
@@ -1,0 +1,14 @@
+{
+  "waves": [
+    {
+      "subwaves": [
+        { "delay": 0, "enemy": "Raptor", "count": 3, "interval": 0.5 }
+      ]
+    },
+    {
+      "subwaves": [
+        { "delay": 2, "enemy": "Raptor", "count": 2, "interval": 1, "mutators": ["fast", "strong"] }
+      ]
+    }
+  ]
+}

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -1,3 +1,5 @@
 export * from './loop'
 export * from './rng'
 export * from './snapshots'
+export * from './resources'
+export * from './spawner'

--- a/src/engine/resources.ts
+++ b/src/engine/resources.ts
@@ -1,0 +1,49 @@
+export type ResourceType = 'gold' | 'chrono' | 'stability'
+
+export interface ResourceValues {
+  gold: number
+  chrono: number
+  stability: number
+}
+
+export type ResourceListener = (values: ResourceValues) => void
+
+export class ResourceManager {
+  private values: ResourceValues
+  private listeners = new Set<ResourceListener>()
+
+  constructor(initial?: Partial<ResourceValues>) {
+    this.values = {
+      gold: 0,
+      chrono: 0,
+      stability: 0,
+      ...initial,
+    }
+  }
+
+  get(type: ResourceType): number {
+    return this.values[type]
+  }
+
+  add(type: ResourceType, amount: number): void {
+    this.values[type] += amount
+    this.emit()
+  }
+
+  spend(type: ResourceType, amount: number): boolean {
+    if (this.values[type] < amount) return false
+    this.values[type] -= amount
+    this.emit()
+    return true
+  }
+
+  subscribe(fn: ResourceListener): () => void {
+    this.listeners.add(fn)
+    fn(this.values)
+    return () => this.listeners.delete(fn)
+  }
+
+  private emit(): void {
+    for (const fn of this.listeners) fn(this.values)
+  }
+}

--- a/src/engine/spawner.ts
+++ b/src/engine/spawner.ts
@@ -1,0 +1,56 @@
+import { Xorshift128Plus } from '@engine/rng'
+
+export interface WaveFile {
+  waves: Wave[]
+}
+
+export interface Wave {
+  subwaves: Subwave[]
+}
+
+export interface Subwave {
+  delay: number
+  enemy: string
+  count: number
+  interval: number
+  mutators?: string[]
+}
+
+export interface SpawnEvent {
+  time: number
+  enemy: string
+  mutator?: string
+}
+
+export function createSpawnPlan(data: WaveFile, seed: number | bigint): SpawnEvent[] {
+  const rng = new Xorshift128Plus(BigInt(seed))
+  let current = 0
+  const events: SpawnEvent[] = []
+  for (const wave of data.waves) {
+    for (const sub of wave.subwaves) {
+      current += sub.delay
+      for (let i = 0; i < sub.count; i++) {
+        const mutator = sub.mutators
+          ? sub.mutators[Math.floor(rng.next() * sub.mutators.length)]
+          : undefined
+        events.push({ time: current + i * sub.interval, enemy: sub.enemy, mutator })
+      }
+    }
+  }
+  return events
+}
+
+export class Spawner {
+  private index = 0
+  constructor(private events: SpawnEvent[]) {
+    this.events.sort((a, b) => a.time - b.time)
+  }
+
+  update(elapsed: number): SpawnEvent[] {
+    const spawned: SpawnEvent[] = []
+    while (this.index < this.events.length && this.events[this.index].time <= elapsed) {
+      spawned.push(this.events[this.index++])
+    }
+    return spawned
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,9 @@ import typescriptLogo from './typescript.svg'
 import viteLogo from '/vite.svg'
 import { setupCounter } from './counter.ts'
 import { add } from '@utils/math'
+import { ResourceManager, createSpawnPlan } from '@engine/index'
+import { HUD } from '@ui/index'
+import waves from '@content/waves.sample.json'
 
 document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
   <div>
@@ -24,3 +27,10 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
 
 console.log('add demo', add(1, 2))
 setupCounter(document.querySelector<HTMLButtonElement>('#counter')!)
+
+const resources = new ResourceManager({ gold: 100, chrono: 50, stability: 100 })
+new HUD(resources)
+resources.add('gold', 25)
+
+const plan = createSpawnPlan(waves, 42)
+console.log('spawn plan', plan)

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1,0 +1,26 @@
+import type { ResourceManager, ResourceValues } from '@engine/resources'
+
+export class HUD {
+  private container: HTMLDivElement
+  private gold: HTMLDivElement
+  private chrono: HTMLDivElement
+  private stability: HTMLDivElement
+
+  constructor(manager: ResourceManager) {
+    this.container = document.createElement('div')
+    this.container.id = 'hud'
+    this.gold = document.createElement('div')
+    this.chrono = document.createElement('div')
+    this.stability = document.createElement('div')
+    this.container.append(this.gold, this.chrono, this.stability)
+    document.body.appendChild(this.container)
+
+    manager.subscribe(v => this.update(v))
+  }
+
+  private update(v: ResourceValues): void {
+    this.gold.textContent = `Gold: ${v.gold}`
+    this.chrono.textContent = `Chrono: ${v.chrono}`
+    this.stability.textContent = `Stability: ${v.stability}`
+  }
+}

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,1 +1,1 @@
-// placeholder for ui module
+export * from './hud'

--- a/tests/resources.test.ts
+++ b/tests/resources.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { ResourceManager } from '@engine/resources'
+
+describe('resources', () => {
+  it('tracks and spends resources', () => {
+    const manager = new ResourceManager()
+    let latest = 0
+    manager.subscribe(v => {
+      latest = v.gold
+    })
+    manager.add('gold', 50)
+    expect(manager.get('gold')).toBe(50)
+    expect(latest).toBe(50)
+    expect(manager.spend('gold', 20)).toBe(true)
+    expect(manager.get('gold')).toBe(30)
+    expect(manager.spend('gold', 40)).toBe(false)
+    expect(manager.get('gold')).toBe(30)
+  })
+})

--- a/tests/spawner.test.ts
+++ b/tests/spawner.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import waves from '@content/waves.sample.json'
+import { createSpawnPlan, Spawner } from '@engine/spawner'
+
+describe('spawner', () => {
+  it('produces deterministic plans for same seed', () => {
+    const plan1 = createSpawnPlan(waves, 123)
+    const plan2 = createSpawnPlan(waves, 123)
+    expect(plan1).toEqual(plan2)
+  })
+
+  it('spawns events at correct times', () => {
+    const plan = createSpawnPlan(waves, 1)
+    const spawner = new Spawner(plan)
+    const first = spawner.update(plan[0].time)
+    expect(first.length).toBe(1)
+    expect(first[0].enemy).toBe('Raptor')
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "moduleDetection": "force",
     "noEmit": true,
     "baseUrl": "./src",
+    "resolveJsonModule": true,
     "paths": {
       "@ecs/*": ["ecs/*"],
       "@engine/*": ["engine/*"],


### PR DESCRIPTION
## Summary
- add ResourceManager with HUD bindings for gold, chrono, and stability
- parse waves JSON and generate deterministic spawn plan with seeded RNG
- demo usage in main and support JSON imports

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6899f85d1ba88330b45bfbcadd2a802a