### PR TITLE
Add resource HUD and deterministic wave spawner

### DIFF
--- a/Tasks.md
+++ b/Tasks.md
@@ -101,8 +101,8 @@ Vitest deckt Kombinatorik ab.
 
 ## 5) Ressourcen, Wellen & Spawner
 
-- [ ] T-040: Ressourcen: Gold, Chrono-Energie, Stabilität + HUD
-- [ ] T-041: Wellenparser (waves.json) + Spawner mit Subwellen/Mutatoren
+ - [x] T-040: Ressourcen: Gold, Chrono-Energie, Stabilität + HUD
+ - [x] T-041: Wellenparser (waves.json) + Spawner mit Subwellen/Mutatoren
 
 **Prompt für Codex:**
 

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,1 +1,1 @@
-// placeholder for content module
+export * from './waves'

--- a/src/content/waves.json
+++ b/src/content/waves.json
@@ -1,0 +1,15 @@
+{
+  "waves": [
+    {
+      "subwaves": [
+        { "enemy": "raptor", "count": 3, "interval": 0.5, "delay": 0, "modifiers": ["fast", "strong"] },
+        { "enemy": "knight", "count": 1, "interval": 0, "delay": 2 }
+      ]
+    },
+    {
+      "subwaves": [
+        { "enemy": "automat", "count": 2, "interval": 1, "delay": 0 }
+      ]
+    }
+  ]
+}

--- a/src/content/waves.ts
+++ b/src/content/waves.ts
@@ -1,0 +1,42 @@
+export interface Subwave {
+  enemy: string
+  count: number
+  interval: number
+  delay: number
+  modifiers?: string[]
+}
+
+export interface Wave {
+  subwaves: Subwave[]
+}
+
+export interface WavesFile {
+  waves: Wave[]
+}
+
+function parseSubwave(s: unknown): Subwave {
+  const obj = s as Record<string, unknown>
+  return {
+    enemy: String(obj.enemy),
+    count: Number(obj.count),
+    interval: Number(obj.interval ?? 0),
+    delay: Number(obj.delay ?? 0),
+    modifiers: Array.isArray(obj.modifiers)
+      ? obj.modifiers.map(m => String(m))
+      : undefined,
+  }
+}
+
+export function parseWaves(data: unknown): Wave[] {
+  if (typeof data !== 'object' || data === null)
+    throw new Error('invalid waves data')
+  const wavesRaw = (data as Record<string, unknown>).waves
+  if (!Array.isArray(wavesRaw)) throw new Error('missing waves array')
+  return wavesRaw.map(w => {
+    const obj = w as Record<string, unknown>
+    const subs = Array.isArray(obj.subwaves)
+      ? obj.subwaves.map(parseSubwave)
+      : []
+    return { subwaves: subs }
+  })
+}

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -1,3 +1,5 @@
 export * from './loop'
 export * from './rng'
 export * from './snapshots'
+export * from './resources'
+export * from './spawner'

--- a/src/engine/resources.ts
+++ b/src/engine/resources.ts
@@ -1,0 +1,39 @@
+export type Resource = 'gold' | 'chrono' | 'stability'
+
+export class ResourceManager {
+  private values: Record<Resource, number> = {
+    gold: 0,
+    chrono: 0,
+    stability: 0,
+  }
+
+  private listeners: Record<Resource, Array<(v: number) => void>> = {
+    gold: [],
+    chrono: [],
+    stability: [],
+  }
+
+  get(type: Resource): number {
+    return this.values[type]
+  }
+
+  add(type: Resource, amount: number): void {
+    this.values[type] += amount
+    this.emit(type)
+  }
+
+  spend(type: Resource, amount: number): boolean {
+    if (this.values[type] < amount) return false
+    this.values[type] -= amount
+    this.emit(type)
+    return true
+  }
+
+  on(type: Resource, cb: (value: number) => void): void {
+    this.listeners[type].push(cb)
+  }
+
+  private emit(type: Resource): void {
+    for (const cb of this.listeners[type]) cb(this.values[type])
+  }
+}

--- a/src/engine/spawner.ts
+++ b/src/engine/spawner.ts
@@ -1,0 +1,37 @@
+import { Xorshift128Plus } from './rng'
+import type { Wave } from '@content/waves'
+
+export interface SpawnEvent {
+  time: number
+  enemy: string
+  modifier?: string
+}
+
+export class WaveSpawner {
+  private events: SpawnEvent[] = []
+
+  constructor(waves: Wave[], seed: bigint = 1n) {
+    const rng = new Xorshift128Plus(seed)
+    let currentTime = 0
+    for (const wave of waves) {
+      let waveEnd = 0
+      for (const sub of wave.subwaves) {
+        for (let i = 0; i < sub.count; i++) {
+          const t = currentTime + sub.delay + i * sub.interval
+          const modifier = sub.modifiers
+            ? sub.modifiers[Math.floor(rng.next() * sub.modifiers.length)]
+            : undefined
+          this.events.push({ time: t, enemy: sub.enemy, modifier })
+          const end = sub.delay + sub.count * sub.interval
+          if (end > waveEnd) waveEnd = end
+        }
+      }
+      currentTime += waveEnd
+    }
+    this.events.sort((a, b) => a.time - b.time)
+  }
+
+  getPlan(): SpawnEvent[] {
+    return this.events
+  }
+}

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1,0 +1,12 @@
+import type { Resource, ResourceManager } from '@engine/resources'
+
+export function bindResource(
+  manager: ResourceManager,
+  type: Resource,
+  el: HTMLElement,
+): void {
+  el.textContent = String(manager.get(type))
+  manager.on(type, value => {
+    el.textContent = String(value)
+  })
+}

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,1 +1,1 @@
-// placeholder for ui module
+export * from './hud'

--- a/tests/resources.test.ts
+++ b/tests/resources.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { ResourceManager } from '@engine/resources'
+import { bindResource } from '@ui/hud'
+
+describe('resources', () => {
+  it('updates HUD bindings on change', () => {
+    const manager = new ResourceManager()
+    const el = { textContent: '' } as unknown as HTMLElement
+    bindResource(manager, 'gold', el)
+    expect(el.textContent).toBe('0')
+    manager.add('gold', 10)
+    expect(el.textContent).toBe('10')
+    const ok = manager.spend('gold', 3)
+    expect(ok).toBe(true)
+    expect(el.textContent).toBe('7')
+    const fail = manager.spend('gold', 8)
+    expect(fail).toBe(false)
+    expect(el.textContent).toBe('7')
+  })
+})

--- a/tests/spawner.test.ts
+++ b/tests/spawner.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { parseWaves } from '@content/waves'
+import { WaveSpawner } from '@engine/spawner'
+import fs from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+describe('wave spawner', () => {
+  const data = JSON.parse(
+    fs.readFileSync(resolve(__dirname, '../src/content/waves.json'), 'utf-8'),
+  )
+  const waves = parseWaves(data)
+
+  it('produces identical plans for same seed', () => {
+    const plan1 = new WaveSpawner(waves, 123n).getPlan()
+    const plan2 = new WaveSpawner(waves, 123n).getPlan()
+    expect(plan1).toEqual(plan2)
+  })
+
+  it('produces different plans for different seeds', () => {
+    const plan1 = new WaveSpawner(waves, 1n).getPlan()
+    const plan2 = new WaveSpawner(waves, 2n).getPlan()
+    expect(plan1).not.toEqual(plan2)
+  })
+})


### PR DESCRIPTION
## Summary
- implement resource manager with HUD bindings for gold, chrono, and stability
- parse waves from JSON and generate deterministic spawn plans
- document completion of tasks T-040 and T-041

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6899f85d1ba88330b45bfbcadd2a802a