### PR TITLE
feat: add tower enemy and artifact content

### DIFF
--- a/Tasks.md
+++ b/Tasks.md
@@ -115,9 +115,9 @@ Spawner deterministisch (seeded). Tests für identische Seeds ⇒ identischer Sp
 
 ## 6) Content v1 (Vertical Slice)
 
-- [ ] T-050: Türme (8): Teergrube, Langbogen, Gatling, Mörser, Tesla, Drohnenbucht, Railgun, Grav-Well
-- [ ] T-051: Gegner (8): Raptor, Schildträger, Ritter, Automat, Infiltrator, Phasenläufer, Singularitätsbrut, Wyrmling
-- [ ] T-052: Artefakte (6): Sandschiff, Axiom-Keil, Uhrwerk-Herz, Kohlenkiste, Paradox-Scherbe, Stundenglas-Fehler
+- [x] T-050: Türme (8): Teergrube, Langbogen, Gatling, Mörser, Tesla, Drohnenbucht, Railgun, Grav-Well
+- [x] T-051: Gegner (8): Raptor, Schildträger, Ritter, Automat, Infiltrator, Phasenläufer, Singularitätsbrut, Wyrmling
+- [x] T-052: Artefakte (6): Sandschiff, Axiom-Keil, Uhrwerk-Herz, Kohlenkiste, Paradox-Scherbe, Stundenglas-Fehler
 
 **Prompt für Codex:**
 

--- a/src/content/artifacts.json
+++ b/src/content/artifacts.json
@@ -1,0 +1,10 @@
+{
+  "artifacts": [
+    {"id": "sandship", "name": "Sandschiff", "effect": "speed", "value": 0.1},
+    {"id": "axiom_wedge", "name": "Axiom-Keil", "effect": "armor", "value": 0.2},
+    {"id": "clockwork_heart", "name": "Uhrwerk-Herz", "effect": "regen", "value": 1},
+    {"id": "coal_crate", "name": "Kohlenkiste", "effect": "damage", "value": 2},
+    {"id": "paradox_shard", "name": "Paradox-Scherbe", "effect": "rewind", "value": 0.5},
+    {"id": "hourglass_fault", "name": "Stundenglas-Fehler", "effect": "freeze", "value": 1}
+  ]
+}

--- a/src/content/artifacts.ts
+++ b/src/content/artifacts.ts
@@ -1,0 +1,28 @@
+export interface Artifact {
+  id: string
+  name: string
+  effect: string
+  value: number
+}
+
+export interface ArtifactsFile {
+  artifacts: Artifact[]
+}
+
+function parseArtifact(a: unknown): Artifact {
+  const obj = a as Record<string, unknown>
+  return {
+    id: String(obj.id),
+    name: String(obj.name),
+    effect: String(obj.effect),
+    value: Number(obj.value ?? 0),
+  }
+}
+
+export function parseArtifacts(data: unknown): Artifact[] {
+  if (typeof data !== 'object' || data === null)
+    throw new Error('invalid artifact data')
+  const raw = (data as Record<string, unknown>).artifacts
+  if (!Array.isArray(raw)) throw new Error('missing artifacts array')
+  return raw.map(parseArtifact)
+}

--- a/src/content/enemies.json
+++ b/src/content/enemies.json
@@ -1,0 +1,12 @@
+{
+  "enemies": [
+    {"id": "raptor", "name": "Raptor", "hp": 30, "speed": 1.2},
+    {"id": "shield_bearer", "name": "Schildträger", "hp": 60, "speed": 0.8, "armor": 0.2},
+    {"id": "knight", "name": "Ritter", "hp": 80, "speed": 0.7, "armor": 0.3},
+    {"id": "automaton", "name": "Automat", "hp": 50, "speed": 1.0},
+    {"id": "infiltrator", "name": "Infiltrator", "hp": 25, "speed": 1.5},
+    {"id": "phase_runner", "name": "Phasenläufer", "hp": 40, "speed": 1.0, "phaseShift": true},
+    {"id": "singularity_brood", "name": "Singularitätsbrut", "hp": 100, "speed": 0.6},
+    {"id": "wyrmling", "name": "Wyrmling", "hp": 20, "speed": 1.3}
+  ]
+}

--- a/src/content/enemies.ts
+++ b/src/content/enemies.ts
@@ -1,0 +1,32 @@
+export interface Enemy {
+  id: string
+  name: string
+  hp: number
+  speed: number
+  armor?: number
+  phaseShift?: boolean
+}
+
+export interface EnemiesFile {
+  enemies: Enemy[]
+}
+
+function parseEnemy(e: unknown): Enemy {
+  const obj = e as Record<string, unknown>
+  return {
+    id: String(obj.id),
+    name: String(obj.name),
+    hp: Number(obj.hp ?? 0),
+    speed: Number(obj.speed ?? 0),
+    armor: obj.armor !== undefined ? Number(obj.armor) : undefined,
+    phaseShift: obj.phaseShift === true,
+  }
+}
+
+export function parseEnemies(data: unknown): Enemy[] {
+  if (typeof data !== 'object' || data === null)
+    throw new Error('invalid enemy data')
+  const raw = (data as Record<string, unknown>).enemies
+  if (!Array.isArray(raw)) throw new Error('missing enemies array')
+  return raw.map(parseEnemy)
+}

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,1 +1,4 @@
 export * from './waves'
+export * from './towers'
+export * from './enemies'
+export * from './artifacts'

--- a/src/content/towers.json
+++ b/src/content/towers.json
@@ -1,0 +1,12 @@
+{
+  "towers": [
+    {"id": "tar_pit", "name": "Teergrube", "damage": 5, "range": 2, "fireRate": 1, "effect": "slow"},
+    {"id": "longbow", "name": "Langbogen", "damage": 8, "range": 5, "fireRate": 1},
+    {"id": "gatling", "name": "Gatling", "damage": 2, "range": 3, "fireRate": 5},
+    {"id": "mortar", "name": "Mörser", "damage": 12, "range": 6, "fireRate": 0.5, "splash": 1},
+    {"id": "tesla", "name": "Tesla", "damage": 6, "range": 4, "fireRate": 1.5, "chain": 3},
+    {"id": "drone_bay", "name": "Drohnenbucht", "damage": 3, "range": 4, "fireRate": 2},
+    {"id": "railgun", "name": "Railgun", "damage": 20, "range": 7, "fireRate": 0.2},
+    {"id": "grav_well", "name": "Grav-Well", "damage": 0, "range": 3, "fireRate": 0.1, "effect": "pull"}
+  ]
+}

--- a/src/content/towers.ts
+++ b/src/content/towers.ts
@@ -1,0 +1,36 @@
+export interface Tower {
+  id: string
+  name: string
+  damage: number
+  range: number
+  fireRate: number
+  effect?: string
+  splash?: number
+  chain?: number
+}
+
+export interface TowersFile {
+  towers: Tower[]
+}
+
+function parseTower(t: unknown): Tower {
+  const obj = t as Record<string, unknown>
+  return {
+    id: String(obj.id),
+    name: String(obj.name),
+    damage: Number(obj.damage ?? 0),
+    range: Number(obj.range ?? 0),
+    fireRate: Number(obj.fireRate ?? 0),
+    effect: obj.effect ? String(obj.effect) : undefined,
+    splash: obj.splash !== undefined ? Number(obj.splash) : undefined,
+    chain: obj.chain !== undefined ? Number(obj.chain) : undefined,
+  }
+}
+
+export function parseTowers(data: unknown): Tower[] {
+  if (typeof data !== 'object' || data === null)
+    throw new Error('invalid tower data')
+  const raw = (data as Record<string, unknown>).towers
+  if (!Array.isArray(raw)) throw new Error('missing towers array')
+  return raw.map(parseTower)
+}

--- a/tests/content.test.ts
+++ b/tests/content.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { parseTowers, parseEnemies, parseArtifacts } from '@content/index'
+import fs from 'node:fs'
+
+function loadJSON(path: string) {
+  return JSON.parse(fs.readFileSync(path, 'utf-8'))
+}
+
+describe('content parsing', () => {
+  it('loads towers from json', () => {
+    const data = loadJSON('src/content/towers.json')
+    const towers = parseTowers(data)
+    expect(towers.length).toBe(8)
+    expect(towers[0]).toMatchObject({ id: 'tar_pit', damage: 5 })
+  })
+
+  it('loads enemies from json', () => {
+    const data = loadJSON('src/content/enemies.json')
+    const enemies = parseEnemies(data)
+    expect(enemies.length).toBe(8)
+    expect(enemies[1]).toMatchObject({ id: 'shield_bearer', armor: 0.2 })
+  })
+
+  it('loads artifacts from json', () => {
+    const data = loadJSON('src/content/artifacts.json')
+    const artifacts = parseArtifacts(data)
+    expect(artifacts.length).toBe(6)
+    expect(artifacts[2]).toMatchObject({ id: 'clockwork_heart', value: 1 })
+  })
+})


### PR DESCRIPTION
## Summary
- add JSON content and parsers for towers, enemies, and artifacts
- test content parsing to ensure data-driven stats
- mark content tasks as complete in project checklist

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6899fa4cc50c8330bcf90586cf420750