### PR TITLE
feat: add audio manager with mixer and rate limits

### DIFF
--- a/Tasks.md
+++ b/Tasks.md
@@ -162,7 +162,7 @@ Build-UI mit Ghost-Placement, Reichweite, Validierung. Overlay-Wheel auf Q/E, Re
 
 ## 9) Audio
 
-- [ ] T-080: WebAudio-SFX (Treffer, Kill, Rewind, Overlay) + Mixer (Mute/Vol)
+- [x] T-080: WebAudio-SFX (Treffer, Kill, Rewind, Overlay) + Mixer (Mute/Vol)
 
 **Prompt für Codex:**
 

--- a/src/audio/index.ts
+++ b/src/audio/index.ts
@@ -1,1 +1,121 @@
-// placeholder for audio module
+export type SfxName = 'hit' | 'kill' | 'rewind' | 'overlay'
+
+interface SfxEntry {
+  buffer: AudioBuffer
+  rateLimit: number
+  lastPlay: number
+}
+
+interface AudioManagerOptions {
+  maxConcurrent?: number
+}
+
+export class AudioManager {
+  private ctx: AudioContext
+  private master: GainNode
+  private music: GainNode
+  private sfx: GainNode
+  private muted = false
+  private masterVolume = 1
+  private maxConcurrent: number
+  private activeSources = 0
+  private queue: SfxName[] = []
+  private sfxMap = new Map<SfxName, SfxEntry>()
+
+  constructor(context: AudioContext = new AudioContext(), options: AudioManagerOptions = {}) {
+    this.ctx = context
+    this.master = this.ctx.createGain()
+    this.master.connect(this.ctx.destination)
+
+    this.music = this.ctx.createGain()
+    this.music.connect(this.master)
+
+    this.sfx = this.ctx.createGain()
+    this.sfx.connect(this.master)
+
+    this.maxConcurrent = options.maxConcurrent ?? 8
+  }
+
+  addSfx(name: SfxName, buffer: AudioBuffer, rateLimit = 0.05): void {
+    this.sfxMap.set(name, { buffer, rateLimit, lastPlay: -Infinity })
+  }
+
+  play(name: SfxName): void {
+    const entry = this.sfxMap.get(name)
+    if (!entry) return
+
+    const now = this.ctx.currentTime
+    if (now - entry.lastPlay < entry.rateLimit) return
+
+    if (this.activeSources >= this.maxConcurrent) {
+      this.queue.push(name)
+      return
+    }
+
+    const source = this.ctx.createBufferSource()
+    source.buffer = entry.buffer
+    source.connect(this.sfx)
+    source.addEventListener('ended', () => {
+      this.activeSources--
+      this.flushQueue()
+    })
+    source.start()
+    entry.lastPlay = now
+    this.activeSources++
+  }
+
+  private flushQueue(): void {
+    if (!this.queue.length) return
+    const now = this.ctx.currentTime
+    for (let i = 0; i < this.queue.length && this.activeSources < this.maxConcurrent; ) {
+      const name = this.queue.shift() as SfxName
+      const entry = this.sfxMap.get(name)
+      if (!entry) continue
+      if (now - entry.lastPlay < entry.rateLimit) continue
+      const source = this.ctx.createBufferSource()
+      source.buffer = entry.buffer
+      source.connect(this.sfx)
+      source.addEventListener('ended', () => {
+        this.activeSources--
+        this.flushQueue()
+      })
+      source.start()
+      entry.lastPlay = now
+      this.activeSources++
+    }
+  }
+
+  setMasterVolume(value: number): void {
+    this.masterVolume = Math.max(0, Math.min(1, value))
+    if (!this.muted) this.master.gain.value = this.masterVolume
+  }
+
+  setMusicVolume(value: number): void {
+    this.music.gain.value = Math.max(0, Math.min(1, value))
+  }
+
+  setSfxVolume(value: number): void {
+    this.sfx.gain.value = Math.max(0, Math.min(1, value))
+  }
+
+  setMuted(mute: boolean): void {
+    this.muted = mute
+    this.master.gain.value = mute ? 0 : this.masterVolume
+  }
+
+  get masterVolumeValue(): number {
+    return this.master.gain.value
+  }
+
+  get musicVolumeValue(): number {
+    return this.music.gain.value
+  }
+
+  get sfxVolumeValue(): number {
+    return this.sfx.gain.value
+  }
+
+  get queueLength(): number {
+    return this.queue.length
+  }
+}

--- a/tests/audio.test.ts
+++ b/tests/audio.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { AudioManager } from '@audio/index'
+
+class MockGainNode {
+  gain = { value: 1 }
+  connect() {}
+}
+
+class MockBufferSource {
+  buffer: AudioBuffer | null = null
+  private onended: (() => void) | null = null
+  connect() {}
+  start() {}
+  stop() {
+    this.onended?.()
+  }
+  addEventListener(_type: string, cb: () => void) {
+    this.onended = cb
+  }
+}
+
+class MockAudioContext {
+  currentTime = 0
+  destination = {}
+  sources: MockBufferSource[] = []
+  createGain() {
+    return new MockGainNode() as unknown as GainNode
+  }
+  createBufferSource() {
+    const src = new MockBufferSource()
+    this.sources.push(src)
+    return src as unknown as AudioBufferSourceNode
+  }
+  advance(dt: number) {
+    this.currentTime += dt
+  }
+}
+
+describe('audio manager', () => {
+  it('controls volume and mute', () => {
+    const ctx = new MockAudioContext()
+    const audio = new AudioManager(ctx as unknown as AudioContext)
+    audio.setMasterVolume(0.5)
+    audio.setMusicVolume(0.6)
+    audio.setSfxVolume(0.7)
+    expect(audio.masterVolumeValue).toBeCloseTo(0.5)
+    expect(audio.musicVolumeValue).toBeCloseTo(0.6)
+    expect(audio.sfxVolumeValue).toBeCloseTo(0.7)
+    audio.setMuted(true)
+    expect(audio.masterVolumeValue).toBe(0)
+    audio.setMuted(false)
+    expect(audio.masterVolumeValue).toBeCloseTo(0.5)
+  })
+
+  it('rate limits and queues sfx', () => {
+    const ctx = new MockAudioContext()
+    const audio = new AudioManager(ctx as unknown as AudioContext, { maxConcurrent: 1 })
+    const buffer = {} as AudioBuffer
+    audio.addSfx('hit', buffer, 1)
+    audio.play('hit')
+    expect(ctx.sources.length).toBe(1)
+    audio.play('hit')
+    expect(ctx.sources.length).toBe(1)
+    ctx.advance(1.1)
+    audio.play('hit')
+    expect(audio.queueLength).toBe(1)
+    ctx.sources[0].stop()
+    expect(ctx.sources.length).toBe(2)
+    expect(audio.queueLength).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- implement WebAudio-based AudioManager with master/music/sfx gains
- support queued, rate-limited SFX playback to avoid clipping
- add tests and mark audio task complete

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689a04aff2d88330b83a1b4648eab2cd