### PR TITLE
feat: add meta progression with chronist faction

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,14 @@ pnpm e2e
   /audio          # Audio manager, SFX
   /scenes         # Boot, MainMenu, Map
   /maps           # Tiled JSON + overlays/relic nodes
+  /meta           # Meta progression (factions, tech tree)
   /utils          # Helpers, types, logging
 /tests            # Vitest suites
 /e2e              # Playwright tests
 /docs             # Screenshots, specs
 ```
 
-**Aliases (`tsconfig.json`)**: `@ecs`, `@engine`, `@path`, `@combat`, `@content`, `@ui`, `@audio`, `@scenes`, `@maps`, `@utils`
+**Aliases (`tsconfig.json`)**: `@ecs`, `@engine`, `@path`, `@combat`, `@content`, `@ui`, `@audio`, `@scenes`, `@maps`, `@utils`, `@meta`
 
 ---
 

--- a/Tasks.md
+++ b/Tasks.md
@@ -174,8 +174,8 @@ AudioManager mit Queues, Rate-Limits, Master/Music/SFX Gains. Keine Clipping-Art
 
 ## 10) Meta-Progression
 
-- [ ] T-090: Tech-Tree v1 (Anomalie-Kerne, 8 Upgrades, Save/Load)
-- [ ] T-091: Fraktion „Chronisten“ (billiger Rewind, weniger Gold)
+ - [x] T-090: Tech-Tree v1 (Anomalie-Kerne, 8 Upgrades, Save/Load)
+ - [x] T-091: Fraktion „Chronisten“ (billiger Rewind, weniger Gold)
 
 **Prompt für Codex:**
 

--- a/index.html
+++ b/index.html
@@ -6,7 +6,15 @@
     <title>Zeitbruch</title>
   </head>
   <body>
-    <div id="hud">
+    <div id="menu">
+      <label for="faction-select">Faction:</label>
+      <select id="faction-select">
+        <option value="none">Neutral</option>
+        <option value="chronists">Chronisten</option>
+      </select>
+      <button id="start-btn">Start</button>
+    </div>
+    <div id="hud" style="display: none">
       <div id="resources">
         Gold: <span id="res-gold">0</span>
         Chrono: <span id="res-chrono">0</span>
@@ -15,6 +23,7 @@
       <div id="paradox">Paradox: <span id="paradox-meter">0</span>%</div>
       <div id="wave">Wave: <span id="wave-counter">0</span></div>
       <div id="timeline" class="timeline"></div>
+      <button id="rewind-btn">Rewind 1s</button>
     </div>
     <canvas id="game"></canvas>
     <script type="module" src="/src/main.ts"></script>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,47 +1,80 @@
 import './style.css'
-import { ResourceManager, ParadoxMeter, WaveTracker, WaveSpawner } from '@engine/index'
+import {
+  ResourceManager,
+  ParadoxMeter,
+  WaveTracker,
+  WaveSpawner,
+  SnapshotBuffer,
+  RewindController,
+} from '@engine/index'
 import type { Wave } from '@content/waves'
 import { bindResource, bindParadox, bindWave } from '@ui/hud'
 import { computeMarkers, renderTimeline } from '@ui/timeline'
 import { ControlSettings } from '@ui/controls'
 import { OverlayWheel } from '@ui/overlayWheel'
+import { bindRewindButton } from '@ui/time'
+import { MetaProgression, factions, type FactionId } from '@meta/index'
 
-// basic setup
-const resources = new ResourceManager()
-const paradox = new ParadoxMeter(1n)
-const waves = new WaveTracker()
+const meta = new MetaProgression(window.localStorage)
+const state = meta.getState()
+const menu = document.getElementById('menu')!
+const hud = document.getElementById('hud')!
+const select = document.getElementById('faction-select') as HTMLSelectElement
+select.value = state.faction
 
-bindResource(resources, 'gold', document.getElementById('res-gold')!)
-bindResource(resources, 'chrono', document.getElementById('res-chrono')!)
-bindResource(resources, 'stability', document.getElementById('res-stability')!)
-bindParadox(paradox, document.getElementById('paradox-meter')!)
-bindWave(waves, document.getElementById('wave-counter')!)
+document.getElementById('start-btn')!.addEventListener('click', () => {
+  const faction = select.value as FactionId
+  meta.selectFaction(faction)
+  menu.style.display = 'none'
+  hud.style.display = 'block'
+  startRun(faction)
+})
 
-resources.add('gold', 100)
-resources.add('chrono', 50)
-resources.add('stability', 30)
+function startRun(factionId: FactionId): void {
+  const faction = factions[factionId]
+  const resources = new ResourceManager()
+  const paradox = new ParadoxMeter(1n)
+  const waves = new WaveTracker()
 
-const spawner = new WaveSpawner(
-  [
-    { subwaves: [{ enemy: 'raptor', count: 3, delay: 0, interval: 1 }] },
-    { subwaves: [{ enemy: 'knight', count: 2, delay: 0, interval: 1 }] },
-  ] as Wave[],
-  1n,
-)
-const plan = spawner.getPlan()
-const markers = computeMarkers(plan, 0, 10)
-renderTimeline(markers, document.getElementById('timeline')!)
+  bindResource(resources, 'gold', document.getElementById('res-gold')!)
+  bindResource(resources, 'chrono', document.getElementById('res-chrono')!)
+  bindResource(resources, 'stability', document.getElementById('res-stability')!)
+  bindParadox(paradox, document.getElementById('paradox-meter')!)
+  bindWave(waves, document.getElementById('wave-counter')!)
 
-const controls = new ControlSettings({ 'overlay:prev': 'q', 'overlay:next': 'e' })
-const wheel = new OverlayWheel(controls, () => console.log('prev'), () => console.log('next'))
-window.addEventListener('keydown', e => wheel.handle(e))
+  let gold = 100
+  if (faction.modifiers?.startingGoldMultiplier)
+    gold *= faction.modifiers.startingGoldMultiplier
+  resources.add('gold', gold)
+  resources.add('chrono', 50)
+  resources.add('stability', 30)
 
-// demo paradox fill
-setInterval(() => {
-  paradox.add(5)
-}, 1000)
+  const spawner = new WaveSpawner(
+    [
+      { subwaves: [{ enemy: 'raptor', count: 3, delay: 0, interval: 1 }] },
+      { subwaves: [{ enemy: 'knight', count: 2, delay: 0, interval: 1 }] },
+    ] as Wave[],
+    1n,
+  )
+  const plan = spawner.getPlan()
+  const markers = computeMarkers(plan, 0, 10)
+  renderTimeline(markers, document.getElementById('timeline')!)
 
-// demo wave advance
-setInterval(() => {
-  waves.next()
-}, 5000)
+  const controls = new ControlSettings({ 'overlay:prev': 'q', 'overlay:next': 'e' })
+  const wheel = new OverlayWheel(controls, () => console.log('prev'), () => console.log('next'))
+  window.addEventListener('keydown', e => wheel.handle(e))
+
+  const buffer = new SnapshotBuffer<number>(0.1, 6)
+  const cost = faction.modifiers?.rewindCostMultiplier ?? 1
+  const rewind = new RewindController(buffer, resources, cost)
+  bindRewindButton(document.getElementById('rewind-btn')!, rewind, 1)
+  setInterval(() => buffer.capture(Date.now()), 100)
+
+  setInterval(() => {
+    paradox.add(5)
+  }, 1000)
+
+  setInterval(() => {
+    waves.next()
+  }, 5000)
+}

--- a/src/meta/factions.ts
+++ b/src/meta/factions.ts
@@ -1,0 +1,21 @@
+export type FactionId = 'none' | 'chronists'
+
+export interface Faction {
+  id: FactionId
+  name: string
+  modifiers?: {
+    /** Multiplies rewind energy cost per second */
+    rewindCostMultiplier?: number
+    /** Multiplies starting gold at run init */
+    startingGoldMultiplier?: number
+  }
+}
+
+export const factions: Record<FactionId, Faction> = {
+  none: { id: 'none', name: 'Neutral', modifiers: {} },
+  chronists: {
+    id: 'chronists',
+    name: 'Chronisten',
+    modifiers: { rewindCostMultiplier: 0.5, startingGoldMultiplier: 0.8 },
+  },
+}

--- a/src/meta/index.ts
+++ b/src/meta/index.ts
@@ -1,0 +1,2 @@
+export * from './factions'
+export * from './progression'

--- a/src/meta/progression.ts
+++ b/src/meta/progression.ts
@@ -1,0 +1,92 @@
+import type { FactionId } from './factions'
+
+export interface StorageLike {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+}
+
+export const UPGRADE_IDS = [
+  'tower-range',
+  'tower-damage',
+  'tower-speed',
+  'chrono-efficiency',
+  'gold-gain',
+  'stability-buffer',
+  'paradox-resist',
+  'rewind-buffer',
+] as const
+
+export type UpgradeId = (typeof UPGRADE_IDS)[number]
+
+export interface MetaState {
+  version: number
+  faction: FactionId
+  anomalyCores: number
+  upgrades: Record<UpgradeId, boolean>
+}
+
+const DEFAULT_STATE: MetaState = {
+  version: 1,
+  faction: 'none',
+  anomalyCores: 0,
+  upgrades: Object.fromEntries(UPGRADE_IDS.map(id => [id, false])) as Record<
+    UpgradeId,
+    boolean
+  >,
+}
+
+const STORAGE_KEY = 'zeitbruch_meta'
+
+function mergeState(state: Partial<MetaState>): MetaState {
+  return {
+    ...DEFAULT_STATE,
+    ...state,
+    version: DEFAULT_STATE.version,
+    upgrades: {
+      ...DEFAULT_STATE.upgrades,
+      ...(state.upgrades ?? {}),
+    },
+  }
+}
+
+export class MetaProgression {
+  private state: MetaState
+
+  constructor(private storage: StorageLike) {
+    this.state = this.load()
+  }
+
+  private load(): MetaState {
+    const raw = this.storage.getItem(STORAGE_KEY)
+    if (!raw) return structuredClone(DEFAULT_STATE)
+    try {
+      const parsed = JSON.parse(raw) as Partial<MetaState>
+      const merged = mergeState(parsed)
+      if (parsed.version !== DEFAULT_STATE.version)
+        this.storage.setItem(STORAGE_KEY, JSON.stringify(merged))
+      return merged
+    } catch {
+      return structuredClone(DEFAULT_STATE)
+    }
+  }
+
+  save(): void {
+    this.storage.setItem(STORAGE_KEY, JSON.stringify(this.state))
+  }
+
+  getState(): MetaState {
+    return this.state
+  }
+
+  selectFaction(f: FactionId): void {
+    this.state.faction = f
+    this.save()
+  }
+
+  unlock(id: UpgradeId): boolean {
+    if (this.state.upgrades[id]) return false
+    this.state.upgrades[id] = true
+    this.save()
+    return true
+  }
+}

--- a/tests/metaProgression.test.ts
+++ b/tests/metaProgression.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { MetaProgression } from '@meta/index'
+import type { StorageLike } from '@meta/progression'
+
+function createStorage(): StorageLike {
+  const map = new Map<string, string>()
+  return {
+    getItem: key => map.get(key) ?? null,
+    setItem: (key, value) => {
+      map.set(key, value)
+    },
+  }
+}
+
+describe('meta progression', () => {
+  it('persists selected faction', () => {
+    const storage = createStorage()
+    const meta = new MetaProgression(storage)
+    meta.selectFaction('chronists')
+    const again = new MetaProgression(storage)
+    expect(again.getState().faction).toBe('chronists')
+  })
+
+  it('migrates old version state', () => {
+    const storage = createStorage()
+    storage.setItem(
+      'zeitbruch_meta',
+      JSON.stringify({ version: 0, faction: 'chronists', anomalyCores: 2, upgrades: {} }),
+    )
+    const meta = new MetaProgression(storage)
+    expect(meta.getState().version).toBe(1)
+    expect(meta.getState().faction).toBe('chronists')
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,8 @@
       "@audio/*": ["audio/*"],
       "@scenes/*": ["scenes/*"],
       "@maps/*": ["maps/*"],
-      "@utils/*": ["utils/*"]
+      "@utils/*": ["utils/*"],
+      "@meta/*": ["meta/*"]
     },
 
     /* Linting */


### PR DESCRIPTION
## Summary
- add meta progression system with 8-upgrade tech tree stored in localStorage
- introduce Chronists faction with cheaper rewinds and reduced starting gold
- wire up main menu faction selection and persistence tests

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689a04c12530833081d20696817e1737