### PR TITLE
feat: add dev level editor and content validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "validate:content": "node scripts/validateContent.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/scripts/validateContent.mjs
+++ b/scripts/validateContent.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/* eslint-env node */
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+
+const errors = []
+
+function readJSON(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf-8'))
+}
+
+function checkUniqueIds(items, file) {
+  const ids = new Set()
+  for (const it of items ?? []) {
+    if (typeof it.id !== 'string') {
+      errors.push(`${file}: missing id`)
+    } else if (ids.has(it.id)) {
+      errors.push(`${file}: duplicate id ${it.id}`)
+    } else {
+      ids.add(it.id)
+    }
+  }
+}
+
+function validateMap(file) {
+  const data = readJSON(file)
+  if (typeof data.width !== 'number' || typeof data.height !== 'number') {
+    errors.push(`${file}: invalid dimensions`)
+  }
+  if (!Array.isArray(data.tiles) || data.tiles.length !== data.width * data.height) {
+    errors.push(`${file}: invalid tiles`)
+  }
+  const nodeIds = new Set()
+  for (const n of data.nodes ?? []) {
+    if (typeof n.id !== 'number') errors.push(`${file}: node missing id`)
+    if (nodeIds.has(n.id)) errors.push(`${file}: duplicate node ${n.id}`)
+    nodeIds.add(n.id)
+  }
+  for (const e of data.edges ?? []) {
+    if (typeof e.from !== 'number' || typeof e.to !== 'number') {
+      errors.push(`${file}: edge refs invalid`)
+    } else if (!nodeIds.has(e.from) || !nodeIds.has(e.to)) {
+      errors.push(`${file}: edge refers unknown node`)
+    }
+  }
+}
+
+function validateContent() {
+  const dir = path.join('src', 'content')
+  checkUniqueIds(readJSON(path.join(dir, 'towers.json')).towers, 'towers.json')
+  checkUniqueIds(readJSON(path.join(dir, 'enemies.json')).enemies, 'enemies.json')
+  checkUniqueIds(readJSON(path.join(dir, 'artifacts.json')).artifacts, 'artifacts.json')
+  const mapsDir = path.join(dir, 'maps')
+  if (fs.existsSync(mapsDir)) {
+    for (const f of fs.readdirSync(mapsDir)) {
+      if (f.endsWith('.json')) validateMap(path.join(mapsDir, f))
+    }
+  }
+}
+
+validateContent()
+if (errors.length) {
+  for (const e of errors) console.error(e)
+  process.exit(1)
+} else {
+  console.log('content ok')
+}

--- a/src/content/maps/demo.json
+++ b/src/content/maps/demo.json
@@ -1,0 +1,18 @@
+{
+  "width": 2,
+  "height": 2,
+  "tiles": [1, 1, 0, 0],
+  "nodes": [
+    { "id": 0, "x": 0, "y": 0 },
+    { "id": 1, "x": 1, "y": 0 }
+  ],
+  "edges": [
+    { "from": 0, "to": 1, "cost": 1, "id": "phase", "enabled": true }
+  ],
+  "overlays": [
+    { "x": 0, "y": 0, "width": 1, "height": 1, "buff": 0.1, "resist": 0.2 }
+  ],
+  "relics": [
+    { "x": 1, "y": 1 }
+  ]
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,10 @@ import { OverlayWheel } from '@ui/overlayWheel'
 import { bindRewindButton } from '@ui/time'
 import { MetaProgression, factions, type FactionId } from '@meta/index'
 
+if (import.meta.env.DEV) {
+  import('@maps/editor')
+}
+
 const meta = new MetaProgression(window.localStorage)
 const state = meta.getState()
 const menu = document.getElementById('menu')!

--- a/src/maps/editor.ts
+++ b/src/maps/editor.ts
@@ -1,0 +1,66 @@
+import type { MapData, MapEdge } from './index'
+import type { OverlayZone } from '@path/overlay'
+
+/** Simple in-memory level editor used in dev builds. */
+export class LevelEditor {
+  private map: MapData
+
+  constructor(width: number, height: number) {
+    this.map = {
+      width,
+      height,
+      tiles: Array(width * height).fill(0),
+      nodes: [],
+      edges: [],
+      overlays: [],
+      relics: [],
+    }
+  }
+
+  static from(data: MapData): LevelEditor {
+    const ed = new LevelEditor(data.width, data.height)
+    ed.map = structuredClone(data)
+    return ed
+  }
+
+  setTile(x: number, y: number, value: number): void {
+    this.map.tiles[y * this.map.width + x] = value
+  }
+
+  addNode(id: number, x: number, y: number): void {
+    this.map.nodes.push({ id, x, y })
+  }
+
+  addEdge(from: number, to: number, cost: number, id?: string, enabled = true): void {
+    const edge: MapEdge = { from, to, cost, id, enabled }
+    this.map.edges.push(edge)
+  }
+
+  toggleEdge(id: string): void {
+    for (const e of this.map.edges) {
+      if (e.id === id) e.enabled = !e.enabled
+    }
+  }
+
+  addOverlay(zone: OverlayZone): void {
+    this.map.overlays.push(zone)
+  }
+
+  addRelic(x: number, y: number): void {
+    this.map.relics.push({ x, y })
+  }
+
+  export(): MapData {
+    return structuredClone(this.map)
+  }
+}
+declare global {
+  interface Window {
+    LevelEditor: typeof LevelEditor
+  }
+}
+
+if (import.meta.env.DEV && typeof window !== 'undefined') {
+  window.LevelEditor = LevelEditor
+}
+

--- a/src/maps/index.ts
+++ b/src/maps/index.ts
@@ -1,1 +1,101 @@
-// placeholder for maps module
+import { Graph, type Node, type Edge } from '@path/graph'
+import { EpochOverlay, type OverlayZone } from '@path/overlay'
+
+export interface MapEdge extends Edge {
+  from: number
+}
+
+export interface RelicNode {
+  x: number
+  y: number
+}
+
+export interface MapData {
+  width: number
+  height: number
+  tiles: number[]
+  nodes: Node[]
+  edges: MapEdge[]
+  overlays: OverlayZone[]
+  relics: RelicNode[]
+}
+
+function isNumber(n: unknown): n is number {
+  return typeof n === 'number'
+}
+
+export function parseMap(data: unknown): MapData {
+  const obj = data as Record<string, unknown>
+  if (!isNumber(obj.width) || !isNumber(obj.height)) {
+    throw new Error('invalid dimensions')
+  }
+  if (!Array.isArray(obj.tiles) || obj.tiles.length !== obj.width * obj.height) {
+    throw new Error('invalid tiles')
+  }
+  const nodes: Node[] = []
+  if (!Array.isArray(obj.nodes)) throw new Error('nodes missing')
+  for (const n of obj.nodes) {
+    if (!isNumber(n.id) || !isNumber(n.x) || !isNumber(n.y)) {
+      throw new Error('invalid node')
+    }
+    nodes.push({ id: n.id, x: n.x, y: n.y })
+  }
+  const edges: MapEdge[] = []
+  if (!Array.isArray(obj.edges)) throw new Error('edges missing')
+  for (const e of obj.edges) {
+    if (
+      !isNumber(e.from) ||
+      !isNumber(e.to) ||
+      !isNumber(e.cost) ||
+      (e.id !== undefined && typeof e.id !== 'string')
+    ) {
+      throw new Error('invalid edge')
+    }
+    edges.push({ from: e.from, to: e.to, cost: e.cost, id: e.id, enabled: e.enabled ?? true })
+  }
+  const overlays: OverlayZone[] = []
+  if (Array.isArray(obj.overlays)) {
+    for (const z of obj.overlays) {
+      if (
+        !isNumber(z.x) ||
+        !isNumber(z.y) ||
+        !isNumber(z.width) ||
+        !isNumber(z.height) ||
+        !isNumber(z.buff) ||
+        !isNumber(z.resist)
+      ) {
+        throw new Error('invalid overlay')
+      }
+      overlays.push({
+        x: z.x,
+        y: z.y,
+        width: z.width,
+        height: z.height,
+        buff: z.buff,
+        resist: z.resist,
+      })
+    }
+  }
+  const relics: RelicNode[] = []
+  if (Array.isArray(obj.relics)) {
+    for (const r of obj.relics) {
+      if (!isNumber(r.x) || !isNumber(r.y)) throw new Error('invalid relic')
+      relics.push({ x: r.x, y: r.y })
+    }
+  }
+  return { width: obj.width, height: obj.height, tiles: [...(obj.tiles as number[])], nodes, edges, overlays, relics }
+}
+
+export function buildGraph(map: MapData): Graph {
+  const g = new Graph()
+  for (const n of map.nodes) g.addNode(n)
+  for (const e of map.edges) g.addEdge(e.from, e.to, e.cost, e.id, e.enabled)
+  return g
+}
+
+export function buildOverlay(map: MapData): EpochOverlay {
+  return new EpochOverlay(map.overlays ?? [])
+}
+
+export { LevelEditor } from './editor'
+

--- a/tests/mapEditor.test.ts
+++ b/tests/mapEditor.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { LevelEditor } from '@maps/editor'
+import { parseMap, buildGraph, buildOverlay } from '@maps/index'
+import fs from 'node:fs'
+
+function loadMap() {
+  return JSON.parse(fs.readFileSync('src/content/maps/demo.json', 'utf-8'))
+}
+
+describe('level editor', () => {
+  it('roundtrips export/import without diff', () => {
+    const ed = new LevelEditor(2, 2)
+    ed.setTile(0, 0, 1)
+    ed.addNode(0, 0, 0)
+    ed.addNode(1, 1, 0)
+    ed.addEdge(0, 1, 1, 'phase')
+    ed.addOverlay({ x: 0, y: 0, width: 1, height: 1, buff: 0.1, resist: 0.2 })
+    ed.addRelic(1, 1)
+    const exported = ed.export()
+    const imported = parseMap(JSON.parse(JSON.stringify(exported)))
+    const ed2 = LevelEditor.from(imported)
+    expect(ed2.export()).toEqual(exported)
+  })
+})
+
+describe('map loading', () => {
+  it('builds graph and overlay from json', () => {
+    const data = parseMap(loadMap())
+    const graph = buildGraph(data)
+    const overlay = buildOverlay(data)
+    expect(graph.findPath(0, 1)).toEqual([0, 1])
+    overlay.activate(1)
+    expect(overlay.isActive()).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- add simple in-memory level editor exposed in dev builds and map parsing utilities
- store example map JSON with overlays and relic spots
- add content validation CLI for IDs and maps and wire into package scripts

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm validate:content`


------
https://chatgpt.com/codex/tasks/task_e_689a09587d6c8330ad3a1d9950399952