### PR TITLE
Enable tower placement, enemy paths and rewind

### DIFF
--- a/src/engine/resources.ts
+++ b/src/engine/resources.ts
@@ -29,6 +29,12 @@ export class ResourceManager {
     return true
   }
 
+  /** Directly set a resource value and notify listeners. */
+  set(type: Resource, value: number): void {
+    this.values[type] = value
+    this.emit(type)
+  }
+
   on(type: Resource, cb: (value: number) => void): void {
     this.listeners[type].push(cb)
   }

--- a/src/ui/build.ts
+++ b/src/ui/build.ts
@@ -24,6 +24,9 @@ export class BuildUI {
       const existing = controls.get(action)
       if (!existing) controls.bind(action, def.key)
     }
+    // Default to the first available tower so players can build without
+    // needing to press a hotkey beforehand.
+    this.selected = defs[0] ?? null
   }
 
   handleKey(key: string): void {

--- a/src/ui/time.ts
+++ b/src/ui/time.ts
@@ -5,9 +5,11 @@ export function bindRewindButton<T>(
   button: HTMLElement,
   controller: RewindController<T>,
   seconds: number,
+  apply: (state: T) => void,
 ): void {
   button.addEventListener('click', () => {
-    controller.tryRewind(seconds)
+    const snap = controller.tryRewind(seconds)
+    if (snap) apply(snap)
   })
 }
 


### PR DESCRIPTION
## Summary
- Select first tower by default so players can build immediately
- Allow resources to be reset and hook rewind button with state snapshots
- Make enemies follow a waypoint path and support rewinding their state

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm typecheck` *(fails: Object literal may only specify known properties...)*

------
https://chatgpt.com/codex/tasks/task_e_689af065ed808330bdf0a9cb29d93099