### PR TITLE
Add paradox event effects and feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
       </div>
       <div id="paradox">Paradox: <span id="paradox-meter">0</span>%</div>
       <div id="wave">Wave: <span id="wave-counter">0</span></div>
+      <div id="paradox-event"></div>
       <div id="timeline" class="timeline"></div>
       <button id="rewind-btn">Rewind 1s</button>
     </div>


### PR DESCRIPTION
## Summary
- display paradox events in HUD and react by spawning extra enemy
- draw enemy path and targets for better movement clarity
- add simple audio cues for tower hits, kills, and paradox events

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689af28e622c8330b5b1bce7c14fe585